### PR TITLE
Fixed `RESET_HOURS_IN_UTC`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export default {
       if (!Number.isNaN(resetHoursInUTC) && (0 <= resetHoursInUTC && resetHoursInUTC <= 23)) {
         nextScheduledTime = new Date();
         nextScheduledTime.setUTCHours(resetHoursInUTC, 0, 0, 0);
+        nextScheduledTime.setDate(nextScheduledTime.getDate() + 1);
       }
       await env.STATUS_KV.put(kvKey, currentStatus, (nextScheduledTime ? { expiration: nextScheduledTime.getTime() / 1000 } : undefined));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,8 @@ export default {
       }
 
       let nextScheduledTime = null;
-      const resetHoursInUTC = env.RESET_HOURS_IN_UTC;
-      if (resetHoursInUTC) {
+      const resetHoursInUTC = parseInt(`${env.RESET_HOURS_IN_UTC}`);
+      if (!Number.isNaN(resetHoursInUTC) && (0 <= resetHoursInUTC && resetHoursInUTC <= 23)) {
         nextScheduledTime = new Date();
         nextScheduledTime.setUTCHours(resetHoursInUTC, 0, 0, 0);
       }


### PR DESCRIPTION
- When `0` was specified for `RESET_HOURS_IN_UTC`, the process to expire the KV did not proceed.
- Fixed a bug where the process to move to the next day was missing, causing the execution to fail after the time set in `RESET_HOURS_IN_UTC`